### PR TITLE
Fix GCO issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ _dev_image: _reqs
 	sudo docker build . --file dev.Dockerfile -t ${CONTAINER_IMAGE_NAME} --build-arg='USER_ID=${CURRENT_USER_ID}' --build-arg='USER_NAME=${CURRENT_USER_NAME}'
 
 
-${BINARY}: ${GO_SOURCES}
+${BINARY}: ${GO_SOURCES} dev.Dockerfile
 	$(call container_make,compile,BINARY=${BINARY})
 
 

--- a/Makefile.container
+++ b/Makefile.container
@@ -7,7 +7,7 @@ export HOME
 
 
 compile:
-	cd src && go build -o ../${BINARY}
+	cd src && CGO_ENABLED=0 go build -o ../${BINARY}
 
 release:
 	tar --create --gzip --file ${BINARY}.tar.gz ${BINARY}

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.0-alpine3.8
+FROM golang:1.11.1-alpine3.8
 
 RUN apk add --no-cache \
 	bash \

--- a/src/main.go
+++ b/src/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 
-const VERSION string = "1.2.1"
+const VERSION string = "1.2.2"
 
 
 func getHelp() string {


### PR DESCRIPTION
Because of the new compilation in the Alpine container, the simpleca
binary could not be run on other distributions. The `GCO_ENABLED` flag
set to 0 fixes this issue.

Also, a newer version of Go is used as well as better dependencies for
the binary to be built with `make`.